### PR TITLE
upgrading to latest request version

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "q": "1.4.1",
-    "request": "2.51.0",
+    "request": "2.69.0",
     "stack-trace": "0.0.9"
   },
   "devDependencies": {


### PR DESCRIPTION
We were running into an error 

```
Unhandled rejection TypeError: Cannot read property 'payload' of undefined
```

when handling a caught error like below with the line `reply(Boom.notFound());`

```
show: (request, reply) => {
  Product.where('id', request.params.id).fetch({require: true})
  .then( (product) => {
    reply(product);
  })
  .catch( (err) => {
    reply(Boom.notFound());
  });
}
```

After a bit of trial and error we were able to track down the problem to a possible dependency conflict.  We pulled a copy of this repo updated the dependency for `request` and our error magically disappeared.
